### PR TITLE
Restrict .svg image uploads

### DIFF
--- a/sdkjs/common/editorscommon.js
+++ b/sdkjs/common/editorscommon.js
@@ -1714,7 +1714,7 @@
 	//todo get from server config
 	var c_oAscImageUploadProp = {//Не все браузеры позволяют получить информацию о файле до загрузки(например ie9), меняя параметры здесь надо поменять аналогичные параметры в web.common
 		MaxFileSize:      25000000, //25 mb
-		SupportedFormats: ["jpg", "jpeg", "jpe", "png", "gif", "bmp", "svg", "tiff", "tif"]
+		SupportedFormats: ["jpg", "jpeg", "jpe", "png", "gif", "bmp", "tiff", "tif"]
 	};
 
 	var c_oAscDocumentUploadProp = {


### PR DESCRIPTION
- error modal about incompatible file type now appears when svg images are added through d&d 